### PR TITLE
Derive WSDL from API endpoint

### DIFF
--- a/lib/marketo_api/client.rb
+++ b/lib/marketo_api/client.rb
@@ -21,6 +21,7 @@ class MarketoAPI::Client
     namespaces:              { 'xmlns:ns1' => 'http://www.marketo.com/mktows/' },
     pretty_print_xml:        true,
     ssl_verify_mode:         :none,
+    ssl_version:             :TLSv1,
     convert_request_keys_to: :none,
   }.freeze
   DEFAULT_CONFIG.values.each(&:freeze)
@@ -69,6 +70,7 @@ class MarketoAPI::Client
   # +ssl_verify_mode+::  How to verify SSL keys. This version defaults to
   #                      +none+. Version 1.0 will default to normal
   #                      verification.
+  # +ssl_version+::      The SSL version to use. Defaults to TLSv1.
   # +headers+::          Headers to use. Defaults to Connection: Keep-Alive.
   #                      Version 1.0 will enforce at least this value.
   #
@@ -85,8 +87,8 @@ class MarketoAPI::Client
     encryption_key = config.delete(:encryption_key)
     @auth = AuthHeader.new(user_id, encryption_key)
 
-    @wsdl = "http://app.marketo.com/soap/mktows/#{api_version}?WSDL".freeze
     @endpoint = "https://#{subdomain}.mktoapi.com/soap/mktows/#{api_version}".freeze
+    @wsdl = "#{@endpoint}?WSDL".freeze
     @savon = Savon.client(config.merge(wsdl: wsdl, endpoint: endpoint))
   end
 

--- a/test/marketo_api/test_client.rb
+++ b/test/marketo_api/test_client.rb
@@ -18,18 +18,15 @@ class TestMarketoAPIClient < Minitest::Test
     assert_equal 'testable', setup_client(api_subdomain: 'testable').subdomain
   end
 
-  def test_wsdl
-    assert_equal "http://app.marketo.com/soap/mktows/2_3?WSDL",
-      subject.wsdl
-    assert_equal "http://app.marketo.com/soap/mktows/2_4?WSDL",
-      setup_client(api_version: '2_4').wsdl
-  end
-
   def test_endpoint
     assert_equal "https://123-ABC-456.mktoapi.com/soap/mktows/2_3",
       subject.endpoint
     assert_equal "https://testable.mktoapi.com/soap/mktows/2_4",
       setup_client(api_subdomain: 'testable', api_version: '2_4').endpoint
+  end
+
+  def test_wsdl
+    assert_equal "#{subject.endpoint}?WSDL", subject.wsdl
   end
 
   def test_generated_methods


### PR DESCRIPTION
The `http://app.marketo.com/soap/mktows/version` endpoint has been deprecated. The WSDL is now derived from the unique API endpoint of each Marketo instance.
